### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,40 +13,33 @@ jobs:
         node: [16]
         os: [ubuntu-20.04]
     name: Ecommerce Sample App
-    env:
-      STARGATE_BASE_URL: http://localhost:8082
-      STARGATE_AUTH_URL: http://localhost:8081/v1/auth
-      STARGATE_USERNAME: cassandra
-      STARGATE_PASSWORD: cassandra
-    services:
-      stargate:
-        image: stargateio/stargate-4_0:v1.0.65
-        env:
-          CLUSTER_NAME: stargate
-          DEVELOPER_MODE: true
-          CLUSTER_VERSION: 4.0 
-        ports:
-          - 8080:8080
-          - 8081:8081
-          - 8082:8082
-          - 9042:9042
     steps:
+      ## Set up Stargate
+      - name: disable and stop mono-xsp4.service
+        run: |
+          sudo kill -9 $(sudo lsof -t -i:8084)
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          repository: stargate/stargate-mongoose
+          path: stargate-mongoose
+          ref: main
+      - name: Set up JSON API
+        run: |
+          chmod +x bin/start_json_api.sh
+          bin/start_json_api.sh -t v2.0.9 -j v1.0.0-ALPHA-4
+        working-directory: stargate-mongoose
+      - name: Wait for services
+        run: |
+          while ! nc -z localhost 8080; do sleep 1; done
+          while ! nc -z localhost 8081; do sleep 1; done
+        working-directory: stargate-mongoose
+      ## Set up and run ecommerce sample app tests
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       - name: Setup node
         uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # v3.1.1
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-        with:
-          repository: stargate/stargate-mongoose
-          path: stargate-mongoose
-          ref: stargatification
-      - run: npm install
-        working-directory: stargate-mongoose
-      - run: npm run build
-        working-directory: stargate-mongoose
-      - run: node ../.scripts/create-tarball.js
-        working-directory: stargate-mongoose
+      
       - run: npm install
         working-directory: netlify-functions-ecommerce
       - run: npm test

--- a/netlify-functions-ecommerce/.config/test.js
+++ b/netlify-functions-ecommerce/.config/test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = Object.freeze({
-  stargateJSONUri: 'http://127.0.0.1:8080/v1/ecommerce_test',
+  stargateJSONUri: 'http://localhost:8080/v1/ecommerce_test',
   stargateJSONUsername: 'cassandra',
   stargateJSONPassword: 'cassandra',
   stargateJSONAuthUrl: 'http://localhost:8081/v1/auth',

--- a/netlify-functions-ecommerce/package.json
+++ b/netlify-functions-ecommerce/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "stargate-mongoose": "0.2.0-ALPHA-1",
+    "stargate-mongoose": "0.2.0-ALPHA-2",
     "mongoose": "7.x",
     "sinon": "14.0.0",
     "stripe": "9.6.0"


### PR DESCRIPTION
Borrowed heavily from https://github.com/stargate/stargate-mongoose/blob/cbd25c0949616520920e1e1947181d8ab5b9fa90/.github/workflows/ci-tests.yml#L18-L29, thanks @kathirsvn . This Workflow clones the stargate-mongoose repo and uses the `bin/start_json_api.sh` script to start stargate-mongoose.

@kathirsvn @jeffreyscarpenter what do you think about including the `bin/start_json_api.sh` and `bin/docker-compose.yml` files in the npm package? Given that stargate's JSON API is relatively new and there isn't much content out there on how to run it, I think it would be nice to include a nice one-line command to run the JSON API.