### PR TITLE
Kathirsvn/astra test

### DIFF
--- a/discord-bot/.env.example
+++ b/discord-bot/.env.example
@@ -1,6 +1,10 @@
 DISCORD_GUILD_ID=test
 DISCORD_CLIENT_ID=test
 DISCORD_TOKEN=test
+#'ASTRA_JSON_API_URL' takes precedence over 'STARGATE_JSON_API_URL' when both are present, and the token is expected to be present as part of the 'ASTRA_JSON_API_URL'
+#'ASTRA_JSON_API_URL' format : https://${ASTRA_DB_ID}-${ASTRA_DB_REGION}.apps.astra.datastax.com/api/json/v1/${ASTRA_KEYSPACE}?applicationToken=${ASTRA_DB_APPLICATION_TOKEN}
+#For example: https://64c2aea9-0390-4ae0-bf5e-f41ad360d340-eu-west-1.apps.astra-test.datastax.com/api/json/v1/json_store?applicationToken=AstraCS:asdsadsadaSd:asdads
+ASTRA_JSON_API_URL=
 STARGATE_JSON_API_URL=http://127.0.0.1:8080/v1/discordbot
 STARGATE_JSON_USERNAME=cassandra
 STARGATE_JSON_PASSWORD=cassandra

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -52,12 +52,15 @@ client.on('interactionCreate', async interaction => {
 run();
 
 async function run() {
-  console.log('Connecting to', process.env.STARGATE_JSON_API_URL);
-  await mongoose.connect(process.env.STARGATE_JSON_API_URL, {
+  const url = process.env.ASTRA_JSON_API_URL || process.env.STARGATE_JSON_API_URL;
+  const isAstra = process.env.ASTRA_JSON_API_URL;
+  const options = isAstra ? { createNamespaceOnConnect: false } : {
     username: process.env.STARGATE_JSON_USERNAME,
     password: process.env.STARGATE_JSON_PASSWORD,
     authUrl: process.env.STARGATE_JSON_AUTH_URL
-  });
+  };
+  console.log('Connecting to', url);
+  await mongoose.connect(url, options);
   // Login to Discord with your client's token
   client.login(token);
 }

--- a/netlify-functions-ecommerce/.config/development.js
+++ b/netlify-functions-ecommerce/.config/development.js
@@ -1,6 +1,11 @@
 'use strict';
 
+//'astraJSONUri' takes precedence over 'stargateJSONUri' when both are present, and the token is expected to be present as part of the 'astraJSONUri'
+//'astraJSONUri' format : https://${ASTRA_DB_ID}-${ASTRA_DB_REGION}.apps.astra.datastax.com/api/json/v1/${ASTRA_KEYSPACE}?applicationToken=${ASTRA_DB_APPLICATION_TOKEN}
+//For example: https://64c2aea9-0390-4ae0-bf5e-f41ad360d340-eu-west-1.apps.astra-test.datastax.com/api/json/v1/json_store?applicationToken=AstraCS:asdsadsadaSd:asdads
+
 module.exports = Object.freeze({
+  astraJSONUri: '',
   stargateJSONUri: 'http://127.0.0.1:8080/v1/ecommerce',
   stargateJSONUsername: 'cassandra',
   stargateJSONPassword: 'cassandra',

--- a/netlify-functions-ecommerce/connect.js
+++ b/netlify-functions-ecommerce/connect.js
@@ -13,14 +13,20 @@ module.exports = async function connect() {
   }
   conn = mongoose.connection;
 
-  let uri = config.stargateJSONUri;
+  const isAstra = config.astraJSONUri;
 
-  await mongoose.connect(uri, {
-    username: config.stargateJSONUsername,
-    password: config.stargateJSONPassword,
-    authUrl: config.stargateJSONAuthUrl
-  });
-  
+  const uri = isAstra ? config.astraJSONUri : config.stargateJSONUri;
+  const options =
+    isAstra ? {
+      createNamespaceOnConnect: false
+    } :
+      {
+        username: config.stargateJSONUsername,
+        password: config.stargateJSONPassword,
+        authUrl: config.stargateJSONAuthUrl
+      };
+  await mongoose.connect(uri, options);
+
   await Promise.all(Object.values(mongoose.connection.models).map(Model => Model.init()));
   return conn;
 };

--- a/typescript-express-reviews/.env
+++ b/typescript-express-reviews/.env
@@ -1,7 +1,7 @@
 #'ASTRA_JSON_API_URL' takes precedence over 'STARGATE_JSON_API_URL' when both are present, and the token is expected to be present as part of the 'ASTRA_JSON_API_URL'
 #'ASTRA_JSON_API_URL' format : https://${ASTRA_DB_ID}-${ASTRA_DB_REGION}.apps.astra.datastax.com/api/json/v1/${ASTRA_KEYSPACE}?applicationToken=${ASTRA_DB_APPLICATION_TOKEN}
 #For example: https://64c2aea9-0390-4ae0-bf5e-f41ad360d340-eu-west-1.apps.astra-test.datastax.com/api/json/v1/json_store?applicationToken=AstraCS:asdsadsadaSd:asdads
-ASTRA_JSON_API_URL=https://64c2aea9-0390-4ae0-bf5e-f41ad360d340-eu-west-1.apps.astra-test.datastax.com/api/json/v1/json_store?applicationToken=AstraCS:xgGIkmSqrcMHZuiNpYEujKpa:ad46aad0c40f45cfbd776ade394a4f3044b4c1717b9f27c43078e767ac411069
+ASTRA_JSON_API_URL=
 STARGATE_JSON_API_URL=http://127.0.0.1:8080/v1/reviews
 STARGATE_JSON_USERNAME=cassandra
 STARGATE_JSON_PASSWORD=cassandra

--- a/typescript-express-reviews/.env
+++ b/typescript-express-reviews/.env
@@ -1,3 +1,7 @@
+#'ASTRA_JSON_API_URL' takes precedence over 'STARGATE_JSON_API_URL' when both are present, and the token is expected to be present as part of the 'ASTRA_JSON_API_URL'
+#'ASTRA_JSON_API_URL' format : https://${ASTRA_DB_ID}-${ASTRA_DB_REGION}.apps.astra.datastax.com/api/json/v1/${ASTRA_KEYSPACE}?applicationToken=${ASTRA_DB_APPLICATION_TOKEN}
+#For example: https://64c2aea9-0390-4ae0-bf5e-f41ad360d340-eu-west-1.apps.astra-test.datastax.com/api/json/v1/json_store?applicationToken=AstraCS:asdsadsadaSd:asdads
+ASTRA_JSON_API_URL=https://64c2aea9-0390-4ae0-bf5e-f41ad360d340-eu-west-1.apps.astra-test.datastax.com/api/json/v1/json_store?applicationToken=AstraCS:xgGIkmSqrcMHZuiNpYEujKpa:ad46aad0c40f45cfbd776ade394a4f3044b4c1717b9f27c43078e767ac411069
 STARGATE_JSON_API_URL=http://127.0.0.1:8080/v1/reviews
 STARGATE_JSON_USERNAME=cassandra
 STARGATE_JSON_PASSWORD=cassandra

--- a/typescript-express-reviews/.env.test
+++ b/typescript-express-reviews/.env.test
@@ -1,3 +1,7 @@
+#'ASTRA_JSON_API_URL' takes precedence over 'STARGATE_JSON_API_URL' when both are present, and the token is expected to be present as part of the 'ASTRA_JSON_API_URL'
+#'ASTRA_JSON_API_URL' format : https://${ASTRA_DB_ID}-${ASTRA_DB_REGION}.apps.astra.datastax.com/api/json/v1/${ASTRA_KEYSPACE}?applicationToken=${ASTRA_DB_APPLICATION_TOKEN}
+#For example: https://64c2aea9-0390-4ae0-bf5e-f41ad360d340-eu-west-1.apps.astra-test.datastax.com/api/json/v1/json_store?applicationToken=AstraCS:asdsadsadaSd:asdads
+ASTRA_JSON_API_URL=
 STARGATE_JSON_API_URL=http://127.0.0.1:8080/v1/reviews_test
 STARGATE_JSON_USERNAME=cassandra
 STARGATE_JSON_PASSWORD=cassandra

--- a/typescript-express-reviews/src/models/connect.ts
+++ b/typescript-express-reviews/src/models/connect.ts
@@ -1,29 +1,35 @@
 import assert from 'assert';
 import mongoose from './mongoose';
 
+const astraJSONAPIURL = process.env.ASTRA_JSON_API_URL ?? '';
 const stargateJSONAPIURL = process.env.STARGATE_JSON_API_URL ?? '';
 const username = process.env.STARGATE_JSON_USERNAME ?? '';
 const password = process.env.STARGATE_JSON_PASSWORD ?? '';
 const authUrl = process.env.STARGATE_JSON_AUTH_URL ?? '';
-if (!stargateJSONAPIURL) {
-  throw new Error('Must set STARGATE_JSON_API_URL environment variable');
-}
-if (!username) {
-  throw new Error('Must set STARGATE_JSON_USERNAME environment variable');
-}
-if (!password) {
-  throw new Error('Must set STARGATE_JSON_PASSWORD environment variable');
-}
-if (!authUrl) {
-  throw new Error('Must set STARGATE_JSON_AUTH_URL environment variable');
+let options = {};
+//astraJSONAPIURL takes precedence over stargateJSONAPIURL when both are set
+let url = astraJSONAPIURL || stargateJSONAPIURL;
+if (astraJSONAPIURL) {
+  options = { createNamespaceOnConnect: false };
+} else {
+  if (!stargateJSONAPIURL) {
+    throw new Error('Must set STARGATE_JSON_API_URL environment variable');
+  }
+  if (!username) {
+    throw new Error('Must set STARGATE_JSON_USERNAME environment variable');
+  }
+  if (!password) {
+    throw new Error('Must set STARGATE_JSON_PASSWORD environment variable');
+  }
+  if (!authUrl) {
+    throw new Error('Must set STARGATE_JSON_AUTH_URL environment variable');
+  }
+  options = { username, password, authUrl };
 }
 
 export default async function connect() {
-  console.log('Connecting to', process.env.STARGATE_JSON_API_URL);
-  await mongoose.connect(
-    stargateJSONAPIURL,
-    { username, password, authUrl } as mongoose.ConnectOptions
-  );
+  console.log('Connecting to', url);
+  await mongoose.connect(url, options);
 }
 
 


### PR DESCRIPTION
Changes to the sample app to connect to AstraDB JSON API optionally.

- In the `typescript-express-reviews` app and the `discord-bot app`, when `ASTRA_JSON_API_URL` is provided in the `.env` file, the open source JSON API  connection properties are ignored and the app connects to the AstraDB instance.
- In `netlify-functions-ecommerce` app, the AstraDB url needs to be set in the property `astraJSONUri ` in the `netlify-functions-ecommerce/.config/development.js` file