### PR TITLE
use dropDatabase() to clean up state between test runs re: stargate/stargate-mongoose#74, stargate/stargate-mongoose#76

### DIFF
--- a/netlify-functions-ecommerce/connect.js
+++ b/netlify-functions-ecommerce/connect.js
@@ -7,7 +7,7 @@ require('./models');
 
 let conn = null;
 
-module.exports = async function connect() {
+module.exports = async function connect(autoCreate = true) {
   if (conn != null) {
     return conn;
   }
@@ -18,7 +18,8 @@ module.exports = async function connect() {
   await mongoose.connect(uri, {
     username: config.stargateJSONUsername,
     password: config.stargateJSONPassword,
-    authUrl: config.stargateJSONAuthUrl
+    authUrl: config.stargateJSONAuthUrl,
+    autoCreate
   });
   
   await Promise.all(Object.values(mongoose.connection.models).map(Model => Model.init()));

--- a/netlify-functions-ecommerce/mongoose.js
+++ b/netlify-functions-ecommerce/mongoose.js
@@ -2,7 +2,6 @@
 
 const mongoose = require('mongoose');
 
-mongoose.set('autoCreate', true);
 mongoose.set('autoIndex', false);
 mongoose.set('toJSON', { virtuals: true });
 mongoose.set('toObject', { virtuals: true });

--- a/netlify-functions-ecommerce/package.json
+++ b/netlify-functions-ecommerce/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "stargate-mongoose": "0.2.0-ALPHA-2",
+    "stargate-mongoose": "file:../../stargate-mongoose/stargate-mongoose-0.2.0-ALPHA-2.tgz",
     "mongoose": "7.x",
     "sinon": "14.0.0",
     "stripe": "9.6.0"

--- a/netlify-functions-ecommerce/test/setup.test.js
+++ b/netlify-functions-ecommerce/test/setup.test.js
@@ -8,15 +8,11 @@ before(async function() {
   this.timeout(30_000);
   await connect();
 
+  await mongoose.connection.dropDatabase();
+  await mongoose.connection.db.createDatabase();
   await Promise.all(Object.values(mongoose.connection.models).map(Model => Model.createCollection()));
-  await Promise.all(Object.values(mongoose.connection.models).map(Model => Model.deleteMany({})));
 });
 
 after(async function() {
-  this.timeout(30_000);
-  await Promise.all(Object.values(mongoose.connection.models).map(async Model => {
-    await mongoose.connection.dropCollection(Model.collection.collectionName);
-  }));
-
   await mongoose.disconnect();
 });

--- a/netlify-functions-ecommerce/test/setup.test.js
+++ b/netlify-functions-ecommerce/test/setup.test.js
@@ -9,7 +9,6 @@ before(async function() {
   await connect();
 
   await mongoose.connection.dropDatabase();
-  await mongoose.connection.db.createDatabase();
   await Promise.all(Object.values(mongoose.connection.models).map(Model => Model.createCollection()));
 });
 

--- a/netlify-functions-ecommerce/test/setup.test.js
+++ b/netlify-functions-ecommerce/test/setup.test.js
@@ -9,7 +9,9 @@ before(async function() {
   await connect();
 
   await mongoose.connection.dropDatabase();
-  await Promise.all(Object.values(mongoose.connection.models).map(Model => Model.createCollection()));
+
+  const models = Object.values(mongoose.connection.models);
+  await Promise.all(models.map(Model => Model.createCollection()));
 });
 
 after(async function() {

--- a/typescript-express-reviews/package.json
+++ b/typescript-express-reviews/package.json
@@ -19,7 +19,7 @@
     "dotenv": "16.0.1",
     "express": "4.x",
     "mongoose": "7.x",
-    "stargate-mongoose": "0.2.0-ALPHA-2"
+    "stargate-mongoose": "file:../../stargate-mongoose/stargate-mongoose-0.2.0-ALPHA-2.tgz"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",

--- a/typescript-express-reviews/src/models/connect.ts
+++ b/typescript-express-reviews/src/models/connect.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import mongoose from './mongoose';
 
 const stargateJSONAPIURL = process.env.STARGATE_JSON_API_URL ?? '';
@@ -18,11 +17,11 @@ if (!authUrl) {
   throw new Error('Must set STARGATE_JSON_AUTH_URL environment variable');
 }
 
-export default async function connect() {
-  console.log('Connecting to', process.env.STARGATE_JSON_API_URL);
+export default async function connect(autoCreate = true) {
+  console.log('Connecting to', process.env.STARGATE_JSON_API_URL, mongoose.connect.toString());
   await mongoose.connect(
     stargateJSONAPIURL,
-    { username, password, authUrl } as mongoose.ConnectOptions
+    { username, password, authUrl, autoCreate } as mongoose.ConnectOptions
   );
 }
 

--- a/typescript-express-reviews/src/models/connect.ts
+++ b/typescript-express-reviews/src/models/connect.ts
@@ -18,7 +18,7 @@ if (!authUrl) {
 }
 
 export default async function connect(autoCreate = true) {
-  console.log('Connecting to', process.env.STARGATE_JSON_API_URL, mongoose.connect.toString());
+  console.log('Connecting to', process.env.STARGATE_JSON_API_URL);
   await mongoose.connect(
     stargateJSONAPIURL,
     { username, password, authUrl, autoCreate } as mongoose.ConnectOptions

--- a/typescript-express-reviews/src/models/mongoose.ts
+++ b/typescript-express-reviews/src/models/mongoose.ts
@@ -1,6 +1,5 @@
 import mongoose from 'mongoose';
 
-mongoose.set('autoCreate', true);
 mongoose.set('autoIndex', false);
 
 import { driver } from 'stargate-mongoose';

--- a/typescript-express-reviews/tests/index.test.ts
+++ b/typescript-express-reviews/tests/index.test.ts
@@ -8,26 +8,16 @@ import connect from '../src/models/connect';
 import mongoose from '../src/models/mongoose';
 
 before(async function() {
-  this.timeout(10000);
-
-  await connect(false);
-
-  await mongoose.connection.dropDatabase();
-  // Make sure all collections are created in Stargate, because Stargate
-  // doesn't auto create collections.
-  await Promise.all(Object.values(mongoose.models).map(Model => {
-    return Model.createCollection();
-  }));
+  await connect();
 });
 
 beforeEach(async function clearDb() {
-  this.timeout(30000);
-
-  await Promise.all(Object.values(mongoose.models).map(Model => Model.deleteMany({})));
+  this.timeout(30_000);
+  const models = Object.values(mongoose.models);
+  await Promise.all(models.map(Model => Model.createCollection({})));
+  await Promise.all(models.map(Model => Model.deleteMany({})));
 });
 
 after(async function() {
-  this.timeout(30_000);
-  await mongoose.connection.dropDatabase();
   await mongoose.disconnect();
 });

--- a/typescript-express-reviews/tests/index.test.ts
+++ b/typescript-express-reviews/tests/index.test.ts
@@ -13,7 +13,6 @@ before(async function() {
   await connect(false);
 
   await mongoose.connection.dropDatabase();
-  await mongoose.connection.db.createDatabase();
   // Make sure all collections are created in Stargate, because Stargate
   // doesn't auto create collections.
   await Promise.all(Object.values(mongoose.models).map(Model => {


### PR DESCRIPTION
Do not merge until stargate/stargate-mongoose#76 and stargate/stargate-mongoose#74 are released please.

Using `dropDatabase()` either before or after tests run to clear state is a common pattern in Mongoose projects, so with this PR I'm trying to see how that would work with stargate-mongoose. This is what I've managed to come up with.

I think it would be nice if `createCollection()` also called `createDatabase()` to avoid the need for an explicit `createDatabase()` call.