### PR TITLE
working example of using `populate()` (using `$in` under the hood) in sample apps

### DIFF
--- a/typescript-express-reviews/src/api/Review/findByVehicle.ts
+++ b/typescript-express-reviews/src/api/Review/findByVehicle.ts
@@ -15,6 +15,8 @@ async function findByVehicle (request: Request, response: Response): Promise<voi
     sort({ createdAt: -1 }).
     skip(skip).
     limit(limit).
+    populate('user').
+    populate('vehicle').
     setOptions({ sanitizeFilter: true });
   response.status(200).json({ reviews: reviews });
   return;

--- a/typescript-express-reviews/src/api/Vehicle/findById.ts
+++ b/typescript-express-reviews/src/api/Vehicle/findById.ts
@@ -15,6 +15,8 @@ async function last5(request: Request, response: Response): Promise<void> {
     find({ vehicleId: request.query._id }).
     sort({ createdAt: -1 }).
     limit(limit).
+    populate('user').
+    populate('vehicle').
     setOptions({ sanitizeFilter: true });
 
   response.status(200).json({

--- a/typescript-express-reviews/tests/Review.test.ts
+++ b/typescript-express-reviews/tests/Review.test.ts
@@ -1,10 +1,11 @@
-
+import Review from '../src/models/review';
+import Vehicle from '../src/models/vehicle';
+import User from '../src/models/user';
 import { describe, it, before } from 'mocha';
 import assert from 'assert';
 import sinon from 'sinon';
 import create from '../src/api/Review/create';
-import Vehicle from '../src/models/vehicle';
-import User from '../src/models/user';
+import findByVehicle from '../src/api/Review/findByVehicle';
 
 interface ResponseStub {
   status: sinon.SinonStub;
@@ -48,5 +49,58 @@ describe('Review', function() {
     assert(res.json.getCall(0).args[0].review);
     assert.equal(res.json.getCall(0).args[0].review.rating, 4);
     assert.equal(res.json.getCall(0).args[0].review.text, 'The length of this text must be greater than 30 to pass validation.');
+  });
+
+  it('Should find all the reviews for the given vehicleId, adhering to the skip and limit parameters', async function() {
+    const mockRequest = (query) => ({ query });
+    const mockResponse = (): ResponseStub => {
+      const res: ResponseStub = {
+        status: sinon.stub().returnsThis(),
+        json: sinon.stub().returnsThis()
+      };
+      return res;
+    };
+    const user = await User.create({
+      email: 'test@localhost.com',
+      firstName: 'Test',
+      lastName: 'Testerson'
+    });
+    const vehicle = await Vehicle.create(
+      {
+        make: 'Tesla',
+        model: 'Model S',
+        year: 2022,
+        images: [
+          'https://tesla-cdn.thron.com/delivery/public/image/tesla/6139697c-9d6a-4579-837e-a9fc5df4a773/bvlatuR/std/1200x628/Model-3-Homepage-Social-LHD',
+          'https://www.tesla.com/sites/default/files/images/blogs/models_blog_post.jpg'
+        ],
+        numReviews: 0,
+        averageReview: 0
+      },
+    );
+    for (let i = 0; i < 6; i++) {
+      await Review.create({
+        rating: i > 5 ? 5 : i, 
+        text: 'This is a review that must have length greater than 30. ' + i, 
+        vehicleId: vehicle._id,
+        userId: user._id
+      });
+    }
+    vehicle.numReviews = 6;
+    vehicle.averageReview = 3;
+    await vehicle.save();
+    const req = mockRequest({ vehicleId: vehicle._id, limit: 3, skip: 2 });
+    const res = mockResponse();
+    await findByVehicle(req, res);
+
+    const reviews = res.json.getCall(0).args[0].reviews;
+    assert.equal(reviews.length, 3);
+
+    // Test that populate worked
+    assert.equal(reviews[0].vehicle.make, 'Tesla');
+    assert.equal(reviews[0].vehicle.model, 'Model S');
+
+    assert.equal(reviews[0].user.firstName, 'Test');
+    assert.equal(reviews[0].user.lastName, 'Testerson');
   });
 });

--- a/typescript-express-reviews/tests/Vehicle.test.ts
+++ b/typescript-express-reviews/tests/Vehicle.test.ts
@@ -4,7 +4,6 @@ import Review from '../src/models/review';
 import User from '../src/models/user';
 import { describe, it } from 'mocha';
 import findById from '../src/api/Vehicle/findById';
-import findByVehicle from '../src/api/Review/findByVehicle';
 import assert from 'assert';
 import sinon from 'sinon';
 
@@ -60,55 +59,17 @@ describe('Vehicle', function() {
     const res = mockResponse();
     await findById(req, res);
     assert(res.json.getCall(0).args[0].vehicle);
-    assert.equal(res.json.getCall(0).args[0].reviews.length, 5);
-    //Sorting is not supported by the driver at this point
-    //console.log(JSON.stringify(res.json.getCall(0).args[0].reviews));
-    //assert(res.json.getCall(0).args[0].reviews[0].text.endsWith('6'));
+
+    const reviews = res.json.getCall(0).args[0].reviews;
+    assert.equal(reviews.length, 5);
+    
+    // Test that populate worked
+    assert.equal(reviews[0].vehicle.make, 'Tesla');
+    assert.equal(reviews[0].vehicle.model, 'Model S');
+
+    assert.equal(reviews[0].user.firstName, 'Test');
+    assert.equal(reviews[0].user.lastName, 'Testerson');
   });
 
-  it('Should find all the reviews for the given vehicleId, adhering to the skip and limit parameters', async function() {
-    const mockRequest = (query) => ({ query });
-    const mockResponse = (): ResponseStub => {
-      const res: ResponseStub = {
-        status: sinon.stub().returnsThis(),
-        json: sinon.stub().returnsThis()
-      };
-      return res;
-    };
-    const user = await User.create({
-      email: 'test@localhost.com',
-      firstName: 'Test',
-      lastName: 'Testerson'
-    });
-    const vehicle = await Vehicle.create(
-      {
-        make: 'Tesla',
-        model: 'Model S',
-        year: 2022,
-        images: [
-          'https://tesla-cdn.thron.com/delivery/public/image/tesla/6139697c-9d6a-4579-837e-a9fc5df4a773/bvlatuR/std/1200x628/Model-3-Homepage-Social-LHD',
-          'https://www.tesla.com/sites/default/files/images/blogs/models_blog_post.jpg'
-        ],
-        numReviews: 0,
-        averageReview: 0
-      },
-    );
-    for (let i = 0; i < 7; i++) {
-      await Review.create({
-        rating: i > 5 ? 5 : i, 
-        text: 'This is a review that must have length greater than 30. ' + i, 
-        vehicleId: vehicle._id,
-        userId: user._id
-      });
-    }
-    vehicle.numReviews = 6;
-    vehicle.averageReview = 3;
-    await vehicle.save();
-    const req = mockRequest({ vehicleId: vehicle._id, limit: 3, skip: 2 });
-    const res = mockResponse();
-    await findByVehicle(req, res);
-    assert.equal(res.json.getCall(0).args[0].reviews.length, 3);
-    // The following won't work until Stargate supports sorting
-    // assert(res.json.getCall(0).args[0].reviews[0].text.endsWith('6'));
-  });
+  
 });


### PR DESCRIPTION
Looks like `$in` works great for sample apps :+1: