### PR TITLE
remove strict: false from photography sample app

### DIFF
--- a/photography-site-demo.js/.gitignore
+++ b/photography-site-demo.js/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+public/uploads

--- a/photography-site-demo.js/.gitignore
+++ b/photography-site-demo.js/.gitignore
@@ -102,5 +102,3 @@ dist
 
 # TernJS port file
 .tern-port
-
-public/uploads

--- a/photography-site-demo.js/server/models/Photo.js
+++ b/photography-site-demo.js/server/models/Photo.js
@@ -7,8 +7,7 @@ const options = {
       "size": 1536, //embedding array size for openAI embedding api, text->vector
       "function": "cosine",
     }
-  },
-  "strict": false
+  }
 };
 
 const photoSchema = new mongoose.Schema({
@@ -29,6 +28,10 @@ const photoSchema = new mongoose.Schema({
     enum: ['landscape', 'street', 'animal'],
     required: 'This field is required.'
   },
+  $vector: {
+    type: [Number],
+    validate: v => v == null || v.length === 1536
+  }
 }, options);
 
 

--- a/photography-site-demo.js/server/models/PhotoEmbedding.js
+++ b/photography-site-demo.js/server/models/PhotoEmbedding.js
@@ -7,8 +7,7 @@ const options = {
       "size": 1280, //embedding array size for google embedding support, image->vector
       "function": "cosine",
     }
-  },
-  "strict": false
+  }
 };
 
 const photoEmbeddingSchema = new mongoose.Schema({
@@ -29,6 +28,10 @@ const photoEmbeddingSchema = new mongoose.Schema({
     enum: ['landscape', 'street', 'animal'],
     required: 'This field is required.'
   },
+  $vector: {
+    type: [Number],
+    validate: v => v == null || v.length === 1280
+  }
 }, options);
 
 


### PR DESCRIPTION
The reason why the app still works even though `$vector` isn't in the schema is that `strict: false` on Photo and PhotoEmbedding schemas. This PR fixes that. Using `strict: false` is generally not a good idea, because that means Mongoose will store any fields that aren't in the schema.