### PR TITLE
bump netlify CLI to 16.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,5 @@ photography-site-demo/.env
 
 # idea files
 .idea
+# Local Netlify folder
+.netlify

--- a/netlify-functions-ecommerce/.netlify/edge-functions-import-map.json
+++ b/netlify-functions-ecommerce/.netlify/edge-functions-import-map.json
@@ -1,1 +1,1 @@
-{"imports":{"netlify:edge":"https://edge-bootstrap.netlify.app/v1/index.ts"}}
+{"imports":{"@netlify/edge-functions":"https://edge.netlify.com/v1/index.ts","netlify:edge":"https://edge.netlify.com/v1/index.ts"},"scopes":{}}

--- a/netlify-functions-ecommerce/package.json
+++ b/netlify-functions-ecommerce/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "axios": "1.5.0",
     "mocha": "10.2.0",
-    "netlify-cli": "10.7.1"
+    "netlify-cli": "16.2.0"
   },
   "engines": {
     "node": ">=14.0.0"
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "node ./frontend/build",
     "seed": "node ./seed",
-    "start": "netlify dev --dir public",
+    "start": "netlify dev --dir public --functions netlify/functions",
     "test": "mocha ./test/*.test.js",
     "test:smoke": "node ./smoke-test"
   }


### PR DESCRIPTION
Replaces #48. Netlify CLI 16.2.0 requires you to specify `--functions` if you specified `--dir` and want to use Netlify functions.