### PR TITLE
Remove MongoDB as dependency from photography example

### DIFF
--- a/photography-site-demo.js/package.json
+++ b/photography-site-demo.js/package.json
@@ -22,7 +22,6 @@
     "express-ejs-layouts": "^2.5.1",
     "express-fileupload": "^1.2.1",
     "express-session": "^1.17.2",
-    "mongodb": "^4.1.2",
     "mongoose": "^7.4.0",
     "python-shell": "^5.0.0",
     "stargate-mongoose": "0.2.0-ALPHA-5"


### PR DESCRIPTION
Fix #51

MongoDB driver is an unused dependency, and either way mongodb@4 is not compatible with mongoose@7.