### PR TITLE
quick fix for checkout tests

### DIFF
--- a/netlify-functions-ecommerce/test/checkout.test.js
+++ b/netlify-functions-ecommerce/test/checkout.test.js
@@ -36,7 +36,13 @@ describe('Checkout', function() {
     params.body.cartId = result.body._id;
     sinon.stub(stripe.paymentIntents, 'retrieve').returns({ status: 'succeeded', id: '123', brand: 'visa', last4: '1234' });
     sinon.stub(stripe.paymentMethods, 'retrieve').returns({ status: 'succeeded', id: '123', brand: 'visa', last4: '1234' });
-    sinon.stub(stripe.checkout.sessions, 'create').returns({ status: 'succeeded', id: '123', brand: 'visa', last4: '1234' });
+    sinon.stub(stripe.checkout.sessions, 'create').returns({
+      status: 'succeeded',
+      id: '123',
+      brand: 'visa',
+      last4: '1234',
+      url: 'test-checkout-url'
+    });
     
     params.body = JSON.stringify(params.body);
 
@@ -44,6 +50,6 @@ describe('Checkout', function() {
     finish.body = JSON.parse(finish.body);
     assert(finish.body.cart);
     assert.equal(finish.body.cart.total, 1600);
-    assert(finish.body.url);
+    assert.equal(finish.body.url, 'test-checkout-url');
   });
 });


### PR DESCRIPTION
Checkout tests recently started failing, maybe due to some dependabot upgrades. I took a look and the cause was a minor issue in checkout tests, this PR fixes the issue.