### PR TITLE
fix discord bot tests for new JSON API version

### DIFF
--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha test/*.js",
+    "test": "mocha --exit test/*.js",
     "start": "node ./index.js"
   },
   "author": "",

--- a/discord-bot/test/setup.js
+++ b/discord-bot/test/setup.js
@@ -3,7 +3,7 @@
 require('dotenv').config({ path: `${__dirname}/../.env.test` });
 
 const Bot = require('../models/bot');
-const { before } = require('mocha');
+const { after, before } = require('mocha');
 const mongoose = require('../mongoose');
 
 const uri = process.env.JSON_API_URL;
@@ -14,8 +14,13 @@ const jsonApiConnectOptions = {
 };
 
 before(async function() {
-  console.log('Connecting to', uri);
+  this.timeout(15000);
   await mongoose.connect(uri, jsonApiConnectOptions);
+  // dropCollection() can be slower
   await Bot.db.dropCollection('bots').catch(() => {});
   await Bot.createCollection();
+});
+
+after(async function() {
+  await mongoose.disconnect();
 });


### PR DESCRIPTION
Looks like discord bot tests started timing out because of `dropCollection()` being slower.