### PR TITLE
disable package-lock.json for discord-bot

### DIFF
--- a/discord-bot/.npmrc
+++ b/discord-bot/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha --exit test/*.js",
+    "test": "mocha test/*.js",
     "start": "node ./index.js"
   },
   "author": "",


### PR DESCRIPTION
Tests where hanging locally for me with discord-bot, which is why I added `--exit` to the `npm test` script. After a lot of digging, I found the issue was that `package-lock.json` was referring to a WIP http2 version of stargate-mongoose, so my `npm install` was getting a broken version of stargate-mongoose. I figure it is worth it to disable `package-lock.json` for this sample, since we also disable it for all other samples and it will help us avoid similar debugging headaches.