### PR TITLE
avoid unnecessary deleteMany() after createCollection()

### DIFF
--- a/netlify-functions-ecommerce/seed.js
+++ b/netlify-functions-ecommerce/seed.js
@@ -12,14 +12,13 @@ async function createProducts() {
   const existingCollections = await mongoose.connection.listCollections();
   for (const Model of Object.values(models)) {
     if (existingCollections.includes(Model.collection.collectionName)) {
+      console.log('Truncating', Model.collection.collectionName);
+      await Model.deleteMany({});
       continue;
     }
     console.log('Creating', Model.collection.collectionName);
     await Model.createCollection();
   }
-  await Promise.all(
-    Object.values(models).map(Model => Model.deleteMany({}))
-  );
   const { Product } = models;
 
   await Product.create({

--- a/typescript-express-reviews/src/seed/seed.ts
+++ b/typescript-express-reviews/src/seed/seed.ts
@@ -21,13 +21,14 @@ async function run() {
   const existingCollections = await mongoose.connection.listCollections() as unknown as string[];
 
   for (const Model of Object.values(mongoose.connection.models)) {
-    console.log('Resetting collection', Model.collection.collectionName);
     // First ensure the collection exists
     if (!existingCollections.includes(Model.collection.collectionName)) {
+      console.log('Creating collection', Model.collection.collectionName);
       await mongoose.connection.createCollection(Model.collection.collectionName);
+    } else {
+      console.log('Clearing collection', Model.collection.collectionName);
+      await Model.deleteMany({});
     }
-    // Then make sure the collection is empty
-    await Model.deleteMany({});
   }
 
   const users = await User.create([


### PR DESCRIPTION
Quick fix to try to reduce some of the issues I've been running into with `deleteMany()` and `createCollection()` failing on Astra: avoiding unnecessarily calling `deleteMany()` after `createCollection()`