### PR TITLE
photography app: avoid indexing `description`, update stargate-mongoose

### DIFF
--- a/photography-site-demo.js/package.json
+++ b/photography-site-demo.js/package.json
@@ -25,7 +25,7 @@
     "mongoose": "^8.0.3",
     "python-shell": "^5.0.0",
     "mocha": "10.2.0",
-    "stargate-mongoose": "0.4.2"
+    "stargate-mongoose": "0.4.3"
 
   },
   "devDependencies": {

--- a/photography-site-demo.js/package.json
+++ b/photography-site-demo.js/package.json
@@ -25,7 +25,7 @@
     "mongoose": "^8.0.3",
     "python-shell": "^5.0.0",
     "mocha": "10.3.0",
-    "stargate-mongoose": "0.4.3"
+    "stargate-mongoose": "0.5.0"
 
   },
   "devDependencies": {

--- a/photography-site-demo.js/package.json
+++ b/photography-site-demo.js/package.json
@@ -25,8 +25,7 @@
     "mongoose": "^8.0.3",
     "python-shell": "^5.0.0",
     "mocha": "10.3.0",
-    "stargate-mongoose": "0.5.0"
-
+    "stargate-mongoose": "0.5.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/photography-site-demo.js/package.json
+++ b/photography-site-demo.js/package.json
@@ -25,7 +25,7 @@
     "mongoose": "^8.0.3",
     "python-shell": "^5.0.0",
     "mocha": "10.3.0",
-    "stargate-mongoose": "0.5.1"
+    "stargate-mongoose": "0.5.2"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/photography-site-demo.js/server/models/seed.js
+++ b/photography-site-demo.js/server/models/seed.js
@@ -1,11 +1,12 @@
 'use strict';
+
 const Category = require('./Category');
 const Photo = require('./Photo');
 const PhotoEmbedding = require('./PhotoEmbedding');
 const connect = require('./connect');
 const getPhotoEmbedding = require('../utils/imageEmbeddingGenerator');
 const getTextEmbedding = require('../utils/textEmbeddingGenerator');
-
+const mongoose = require('./mongoose');
 
 async function deleteAll() {
   await connect();
@@ -139,6 +140,9 @@ async function populate() {
   await createCategories();
   await createPhotos();
   await createPhotoEmbeddings();
+
+  await mongoose.disconnect();
+  console.log('Done');
 }
 
 populate().catch(error => {

--- a/photography-site-demo.js/server/models/seed.js
+++ b/photography-site-demo.js/server/models/seed.js
@@ -116,7 +116,12 @@ async function createPhotos() {
 
 
 async function createPhotoEmbeddings() {
-  await PhotoEmbedding.createCollection();
+  // Need to disable indexing for embeddings, otherwise creating PhotoEmbeddings
+  // fails with the following error:
+  // "Term of column query_text_values exceeds the byte limit for index. Term size 1.115KiB. Max allowed size 1.000KiB.""
+  await PhotoEmbedding.createCollection({
+    indexing: { deny: ['description'] }
+  });
   for (let i = 0; i < data.length; i++) {
     await PhotoEmbedding.create({
       name: data[i].name,
@@ -136,4 +141,7 @@ async function populate() {
   await createPhotoEmbeddings();
 }
 
-populate();
+populate().catch(error => {
+  console.error(error);
+  process.exit(-1);
+});;


### PR DESCRIPTION
Fix #200

I found a minor issue where the photography app seed script currently fails because some of the descriptions are too long for indexing.