### PR TITLE
make typescript-express-reviews seed script automatically exit when done

### DIFF
--- a/typescript-express-reviews/src/seed/seed.ts
+++ b/typescript-express-reviews/src/seed/seed.ts
@@ -91,5 +91,6 @@ async function run() {
     }
   ]);
 
+  await mongoose.disconnect();
   console.log('Done');
 }


### PR DESCRIPTION
With http2, you now need to explicitly `close()` any connection you open, or that connection will stay open forever and prevent the process from exiting. This PR makes the reviews sample app's seed script call `mongoose.disconnect()`, which is equivalent to calling `close()` on every connection.