### PR TITLE
rename JSON API -> Data API

### DIFF
--- a/discord-bot/.env.example
+++ b/discord-bot/.env.example
@@ -1,10 +1,10 @@
 DISCORD_GUILD_ID=test
 DISCORD_CLIENT_ID=test
 DISCORD_TOKEN=test
-STARGATE_JSON_API_URL=http://127.0.0.1:8181/v1/discordbot
-STARGATE_JSON_USERNAME=cassandra
-STARGATE_JSON_PASSWORD=cassandra
-STARGATE_JSON_AUTH_URL=http://localhost:8081/v1/auth
+DATA_API_URI=http://127.0.0.1:8181/v1/discordbot
+DATA_API_AUTH_USERNAME=cassandra
+DATA_API_AUTH_PASSWORD=cassandra
+DATA_API_AUTH_URL=http://localhost:8081/v1/auth
 
 #Fill the ASTRA DB related details only when IS_ASTRA is set to 'true'
 #IS_ASTRA=true

--- a/discord-bot/.env.test
+++ b/discord-bot/.env.test
@@ -1,4 +1,4 @@
-JSON_API_URL=http://127.0.0.1:8181/v1/discordbot_test
-JSON_API_AUTH_USERNAME=cassandra
-JSON_API_AUTH_PASSWORD=cassandra
-JSON_API_AUTH_URL=http://localhost:8081/v1/auth
+DATA_API_URI=http://127.0.0.1:8181/v1/discordbot_test
+DATA_API_AUTH_USERNAME=cassandra
+DATA_API_AUTH_PASSWORD=cassandra
+DATA_API_AUTH_URL=http://localhost:8081/v1/auth

--- a/discord-bot/connect.js
+++ b/discord-bot/connect.js
@@ -16,11 +16,11 @@ module.exports = async function connect() {
       isAstra: true
     };
   } else {
-    uri = process.env.JSON_API_URL;
+    uri = process.env.DATA_API_URI;
     jsonApiConnectOptions = {
-      username: process.env.JSON_API_AUTH_USERNAME,
-      password: process.env.JSON_API_AUTH_PASSWORD,
-      authUrl: process.env.JSON_API_AUTH_URL
+      username: process.env.DATA_API_AUTH_USERNAME,
+      password: process.env.DATA_API_AUTH_PASSWORD,
+      authUrl: process.env.DATA_API_AUTH_URL
     };
   }
   console.log('Connecting to', uri);

--- a/discord-bot/test/setup.js
+++ b/discord-bot/test/setup.js
@@ -6,11 +6,11 @@ const Bot = require('../models/bot');
 const { after, before } = require('mocha');
 const mongoose = require('../mongoose');
 
-const uri = process.env.JSON_API_URL;
+const uri = process.env.DATA_API_URI;
 const jsonApiConnectOptions = {
-  username: process.env.JSON_API_AUTH_USERNAME,
-  password: process.env.JSON_API_AUTH_PASSWORD,
-  authUrl: process.env.JSON_API_AUTH_URL
+  username: process.env.DATA_API_AUTH_USERNAME,
+  password: process.env.DATA_API_AUTH_PASSWORD,
+  authUrl: process.env.DATA_API_AUTH_URL
 };
 
 before(async function() {

--- a/netlify-functions-ecommerce/.env.example
+++ b/netlify-functions-ecommerce/.env.example
@@ -5,12 +5,12 @@ IS_ASTRA=
 
 #Fill the JSON API related details only when IS_ASTRA is set to 'false'
 #Local JSON API URL for example: http://127.0.0.1:8181/v1/ecommerce_test where 'ecommerce_test' is the keyspace name
-JSON_API_URL=http://127.0.0.1:8181/v1/ecommerce_test
+DATA_API_URI=http://127.0.0.1:8181/v1/ecommerce_test
 #Auth URL for example: http://127.0.0.1:8081/v1/auth
-JSON_API_AUTH_URL=http://127.0.0.1:8081/v1/auth
+DATA_API_AUTH_URL=http://127.0.0.1:8081/v1/auth
 #Auth username and password
-JSON_API_AUTH_USERNAME=cassandra
-JSON_API_AUTH_PASSWORD=cassandra
+DATA_API_AUTH_USERNAME=cassandra
+DATA_API_AUTH_PASSWORD=cassandra
 
 #Fill the ASTRA DB related details only when IS_ASTRA is set to 'true'
 #Astra DB API URL

--- a/netlify-functions-ecommerce/.env.test
+++ b/netlify-functions-ecommerce/.env.test
@@ -1,11 +1,11 @@
 #Fill the Local JSON API related details only when NODE_ENV is set to 'jsonapi'
 #Local JSON API URL for example: http://127.0.0.1:8181/v1/ecommerce_test where 'ecommerce_test' is the keyspace name
-JSON_API_URL=http://127.0.0.1:8181/v1/ecommerce_test
+DATA_API_URI=http://127.0.0.1:8181/v1/ecommerce_test
 #Auth URL for example: http://127.0.0.1:8081/v1/auth
-JSON_API_AUTH_URL=http://127.0.0.1:8081/v1/auth
+DATA_API_AUTH_URL=http://127.0.0.1:8081/v1/auth
 #Auth username and password
-JSON_API_AUTH_USERNAME=cassandra
-JSON_API_AUTH_PASSWORD=cassandra
+DATA_API_AUTH_USERNAME=cassandra
+DATA_API_AUTH_PASSWORD=cassandra
 
 #Fill in Stripe related details if you want to see Stripe integration.
 #Otherwise the sample app will bypass Stripe.

--- a/netlify-functions-ecommerce/README.md
+++ b/netlify-functions-ecommerce/README.md
@@ -15,10 +15,10 @@ Make sure you have a local stargate instance running as described on the [main p
 ### Setting up .env file to run against JSON API
 1. Copy the `.env.example` file to `.env` and fill in the values for the environment variables.
 2. Set `IS_ASTRA` to `false`
-3. Set `JSON_API_URL` to `http://127.0.0.1:8181/v1/ecommerce_test`
-4. Set `JSON_API_AUTH_URL` to `http://127.0.0.1:8081/v1/auth`
-5. Set `JSON_API_AUTH_USERNAME` to `cassandra`
-6. Set `JSON_API_AUTH_PASSWORD` to `cassandra`
+3. Set `DATA_API_URI` to `http://127.0.0.1:8181/v1/ecommerce_test`
+4. Set `DATA_API_AUTH_URI` to `http://127.0.0.1:8081/v1/auth`
+5. Set `DATA_API_AUTH_USERNAME` to `cassandra`
+6. Set `DATA_API_AUTH_PASSWORD` to `cassandra`
 7. Remove `ASTRA_DB_ID`, `ASTRA_DB_REGION`, `ASTRA_DB_KEYSPACE`, `ASTRA_DB_APPLICATION_TOKEN`
 
 ### Setting up .env file to run against AstraDB
@@ -28,7 +28,7 @@ Make sure you have a local stargate instance running as described on the [main p
 4. Set `ASTRA_DB_REGION` to your AstraDB database region
 5. Set `ASTRA_DB_KEYSPACE` to your AstraDB keyspace
 6. Set `ASTRA_DB_APPLICATION_TOKEN` to your AstraDB application token
-7. Remove `JSON_API_URL`, `JSON_API_AUTH_URL`, `JSON_API_AUTH_USERNAME`, `JSON_API_AUTH_PASSWORD`.
+7. Remove `DATA_API_URI`, `DATA_API_AUTH_URI`, `DATA_API_AUTH_USERNAME`, `DATA_API_AUTH_PASSWORD`.
 
 ### running the example
 1. Run `npm install`

--- a/netlify-functions-ecommerce/connect.js
+++ b/netlify-functions-ecommerce/connect.js
@@ -26,11 +26,11 @@ module.exports = async function connect() {
       isAstra: true
     };
   } else {
-    uri = process.env.JSON_API_URL;
+    uri = process.env.DATA_API_URI;
     jsonApiConnectOptions = {
-      username: process.env.JSON_API_AUTH_USERNAME,
-      password: process.env.JSON_API_AUTH_PASSWORD,
-      authUrl: process.env.JSON_API_AUTH_URL
+      username: process.env.DATA_API_AUTH_USERNAME,
+      password: process.env.DATA_API_AUTH_PASSWORD,
+      authUrl: process.env.DATA_API_AUTH_URL
     };
   }
   await mongoose.connect(uri, jsonApiConnectOptions);

--- a/typescript-express-reviews/.env.example
+++ b/typescript-express-reviews/.env.example
@@ -5,12 +5,12 @@ IS_ASTRA=
 
 #Fill the JSON API related details only when IS_ASTRA is set to 'false'
 #Local JSON API URL for example: http://127.0.0.1:8181/v1/ecommerce_test where 'ecommerce_test' is the keyspace name
-JSON_API_URL=http://127.0.0.1:8181/v1/ecommerce_test
+DATA_API_URI=http://127.0.0.1:8181/v1/ecommerce_test
 #Auth URL for example: http://127.0.0.1:8081/v1/auth
-JSON_API_AUTH_URL=http://127.0.0.1:8081/v1/auth
+DATA_API_AUTH_URL=http://127.0.0.1:8081/v1/auth
 #Auth username and password
-JSON_API_AUTH_USERNAME=cassandra
-JSON_API_AUTH_PASSWORD=cassandra
+DATA_API_AUTH_USERNAME=cassandra
+DATA_API_AUTH_PASSWORD=cassandra
 
 #Fill the ASTRA DB related details only when IS_ASTRA is set to 'true'
 #Astra DB API URL

--- a/typescript-express-reviews/.env.test
+++ b/typescript-express-reviews/.env.test
@@ -1,4 +1,4 @@
-STARGATE_JSON_API_URL=http://127.0.0.1:8181/v1/reviews_test
-STARGATE_JSON_USERNAME=cassandra
-STARGATE_JSON_PASSWORD=cassandra
-STARGATE_JSON_AUTH_URL=http://localhost:8081/v1/auth
+DATA_API_URI=http://127.0.0.1:8181/v1/reviews_test
+DATA_API_AUTH_USERNAME=cassandra
+DATA_API_AUTH_PASSWORD=cassandra
+DATA_API_AUTH_URL=http://localhost:8081/v1/auth

--- a/typescript-express-reviews/src/models/connect.ts
+++ b/typescript-express-reviews/src/models/connect.ts
@@ -3,10 +3,10 @@ import mongoose from './mongoose';
 
 const isAstra = process.env.IS_ASTRA ?? '';
 
-const stargateJSONAPIURL = process.env.STARGATE_JSON_API_URL ?? '';
-const username = process.env.STARGATE_JSON_USERNAME ?? '';
-const password = process.env.STARGATE_JSON_PASSWORD ?? '';
-const authUrl = process.env.STARGATE_JSON_AUTH_URL ?? '';
+const dataAPIURI = process.env.DATA_API_URI ?? '';
+const username = process.env.DATA_API_AUTH_USERNAME ?? '';
+const password = process.env.DATA_API_AUTH_PASSWORD ?? '';
+const authUrl = process.env.DATA_API_AUTH_URL ?? '';
 
 const astraAPIEndpoint = process.env.ASTRA_API_ENDPOINT ?? '';
 const astraNamespace = process.env.ASTRA_NAMESPACE ?? '';
@@ -25,9 +25,9 @@ export default async function connect() {
       { isAstra: true } as mongoose.ConnectOptions
     );
   } else {
-    console.log('Connecting to', stargateJSONAPIURL);
+    console.log('Connecting to', dataAPIURI);
     await mongoose.connect(
-      stargateJSONAPIURL,
+      dataAPIURI,
       { username, password, authUrl } as mongoose.ConnectOptions
     );
   }


### PR DESCRIPTION
There's a bunch of places where we use "JSON API" terminology in sample apps, so I went through and renamed to Data API for consistency