### PR TITLE
upgrade stargate-mongoose -> 0.5.7 to fix test timeouts and cap test runs at 5m

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   test-discord-bot:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +51,7 @@ jobs:
 
   test-ecommerce:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
@@ -92,6 +94,7 @@ jobs:
 
   test-reviews:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
@@ -135,6 +138,7 @@ jobs:
 
   test-photograhy:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:

--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -22,7 +22,7 @@
     "dotenv": "16.4.5",
     "eslint": "8.57.0",
     "mongoose": "^8.1",
-    "stargate-mongoose": "0.5.6"
+    "stargate-mongoose": "0.5.7"
   },
   "devDependencies": {
     "mocha": "10.4.0",

--- a/netlify-functions-ecommerce/package.json
+++ b/netlify-functions-ecommerce/package.json
@@ -6,7 +6,7 @@
     "dotenv": "16.4.5",
     "mongoose": "^8.1",
     "sinon": "17.0.1",
-    "stargate-mongoose": "0.5.6",
+    "stargate-mongoose": "0.5.7",
     "stripe": "15.6.0",
     "vanillatoasts": "1.6.0",
     "webpack": "5.x"

--- a/netlify-functions-ecommerce/test/setup.test.js
+++ b/netlify-functions-ecommerce/test/setup.test.js
@@ -15,10 +15,5 @@ before(async function() {
 });
 
 after(async function() {
-  this.timeout(30000);
-  await Promise.all(Object.values(mongoose.connection.models).map(async Model => {
-    await mongoose.connection.dropCollection(Model.collection.collectionName);
-  }));
-
   await mongoose.disconnect();
 });

--- a/photography-site-demo.js/package.json
+++ b/photography-site-demo.js/package.json
@@ -25,7 +25,7 @@
     "mongoose": "^8.0.3",
     "python-shell": "^5.0.0",
     "mocha": "10.4.0",
-    "stargate-mongoose": "0.5.6"
+    "stargate-mongoose": "0.5.7"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/typescript-express-reviews/package.json
+++ b/typescript-express-reviews/package.json
@@ -20,7 +20,7 @@
     "dotenv": "16.4.5",
     "express": "4.x",
     "mongoose": "^8.1",
-    "stargate-mongoose": "0.5.6"
+    "stargate-mongoose": "0.5.7"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",

--- a/typescript-express-reviews/tests/index.test.ts
+++ b/typescript-express-reviews/tests/index.test.ts
@@ -30,10 +30,5 @@ before(async function() {
 });*/
 
 after(async function() {
-  this.timeout(30_000);
-  await Promise.all(Object.values(mongoose.connection.models).map(async Model => {
-    await mongoose.connection.dropCollection(Model.collection.collectionName);
-  }));
-
   await mongoose.disconnect();
 });


### PR DESCRIPTION
Tests have been hanging due to compatibility issues with latest data-api, I'm still debugging exact root cause but upgrading to stargate-mongoose@0.5.7 seems to be enough to fix test issues. But as written, all sample-apps tests hang for 6 hours in master. This PR makes tests pass.

[For example:](https://github.com/stargate/stargate-mongoose-sample-apps/actions/runs/9102884302/job/25023504809)

![image](https://github.com/stargate/stargate-mongoose-sample-apps/assets/1620265/9c50beb2-fea4-40a3-8143-89117760bedc)
