### PR TITLE
Fix GitHub actions tests workflow to handle docker-compose v2 in GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ jobs:
           ref: main
       - name: Set up JSON API
         run: |
+          awk 'NR>1{print prev} {prev=$0} END{}' bin/start_data_api.sh > temp && mv temp bin/start_data_api.sh
+          echo "docker compose -f $SCRIPTS_HOME/docker-compose.yml up -d" >> bin/start_data_api.sh
+          cat bin/start_data_api.sh
           chmod +x bin/start_data_api.sh
           bin/start_data_api.sh
         working-directory: stargate-mongoose
@@ -70,6 +73,9 @@ jobs:
           ref: main
       - name: Set up JSON API
         run: |
+          awk 'NR>1{print prev} {prev=$0} END{}' bin/start_data_api.sh > temp && mv temp bin/start_data_api.sh
+          echo "docker compose -f $SCRIPTS_HOME/docker-compose.yml up -d" >> bin/start_data_api.sh
+          cat bin/start_data_api.sh
           chmod +x bin/start_data_api.sh
           bin/start_data_api.sh
         working-directory: stargate-mongoose
@@ -113,6 +119,9 @@ jobs:
           ref: main
       - name: Set up JSON API
         run: |
+          awk 'NR>1{print prev} {prev=$0} END{}' bin/start_data_api.sh > temp && mv temp bin/start_data_api.sh
+          echo "docker compose -f $SCRIPTS_HOME/docker-compose.yml up -d" >> bin/start_data_api.sh
+          cat bin/start_data_api.sh
           chmod +x bin/start_data_api.sh
           bin/start_data_api.sh
         working-directory: stargate-mongoose
@@ -157,6 +166,9 @@ jobs:
           ref: main
       - name: Set up JSON API
         run: |
+          awk 'NR>1{print prev} {prev=$0} END{}' bin/start_data_api.sh > temp && mv temp bin/start_data_api.sh
+          echo "docker compose -f $SCRIPTS_HOME/docker-compose.yml up -d" >> bin/start_data_api.sh
+          cat bin/start_data_api.sh
           chmod +x bin/start_data_api.sh
           bin/start_data_api.sh
         working-directory: stargate-mongoose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JSON API
         run: |
           awk 'NR>1{print prev} {prev=$0} END{}' bin/start_data_api.sh > temp && mv temp bin/start_data_api.sh
-          echo "docker compose -f $SCRIPTS_HOME/docker-compose.yml up -d" >> bin/start_data_api.sh
+          echo "docker compose -f bin/docker-compose.yml up -d" >> bin/start_data_api.sh
           cat bin/start_data_api.sh
           chmod +x bin/start_data_api.sh
           bin/start_data_api.sh
@@ -74,7 +74,7 @@ jobs:
       - name: Set up JSON API
         run: |
           awk 'NR>1{print prev} {prev=$0} END{}' bin/start_data_api.sh > temp && mv temp bin/start_data_api.sh
-          echo "docker compose -f $SCRIPTS_HOME/docker-compose.yml up -d" >> bin/start_data_api.sh
+          echo "docker compose -f bin/docker-compose.yml up -d" >> bin/start_data_api.sh
           cat bin/start_data_api.sh
           chmod +x bin/start_data_api.sh
           bin/start_data_api.sh
@@ -120,7 +120,7 @@ jobs:
       - name: Set up JSON API
         run: |
           awk 'NR>1{print prev} {prev=$0} END{}' bin/start_data_api.sh > temp && mv temp bin/start_data_api.sh
-          echo "docker compose -f $SCRIPTS_HOME/docker-compose.yml up -d" >> bin/start_data_api.sh
+          echo "docker compose -f bin/docker-compose.yml up -d" >> bin/start_data_api.sh
           cat bin/start_data_api.sh
           chmod +x bin/start_data_api.sh
           bin/start_data_api.sh
@@ -167,7 +167,7 @@ jobs:
       - name: Set up JSON API
         run: |
           awk 'NR>1{print prev} {prev=$0} END{}' bin/start_data_api.sh > temp && mv temp bin/start_data_api.sh
-          echo "docker compose -f $SCRIPTS_HOME/docker-compose.yml up -d" >> bin/start_data_api.sh
+          echo "docker compose -f bin/docker-compose.yml up -d" >> bin/start_data_api.sh
           cat bin/start_data_api.sh
           chmod +x bin/start_data_api.sh
           bin/start_data_api.sh

--- a/discord-bot/.env.example
+++ b/discord-bot/.env.example
@@ -4,7 +4,6 @@ DISCORD_TOKEN=test
 DATA_API_URI=http://127.0.0.1:8181/v1/discordbot
 DATA_API_AUTH_USERNAME=cassandra
 DATA_API_AUTH_PASSWORD=cassandra
-DATA_API_AUTH_URL=http://localhost:8081/v1/auth
 
 #Fill the ASTRA DB related details only when IS_ASTRA is set to 'true'
 #IS_ASTRA=true

--- a/discord-bot/connect.js
+++ b/discord-bot/connect.js
@@ -19,8 +19,7 @@ module.exports = async function connect() {
     uri = process.env.DATA_API_URI;
     jsonApiConnectOptions = {
       username: process.env.DATA_API_AUTH_USERNAME,
-      password: process.env.DATA_API_AUTH_PASSWORD,
-      authUrl: process.env.DATA_API_AUTH_URL
+      password: process.env.DATA_API_AUTH_PASSWORD
     };
   }
   console.log('Connecting to', uri);

--- a/netlify-functions-ecommerce/.env.example
+++ b/netlify-functions-ecommerce/.env.example
@@ -6,8 +6,6 @@ IS_ASTRA=
 #Fill the JSON API related details only when IS_ASTRA is set to 'false'
 #Local JSON API URL for example: http://127.0.0.1:8181/v1/ecommerce_test where 'ecommerce_test' is the keyspace name
 DATA_API_URI=http://127.0.0.1:8181/v1/ecommerce_test
-#Auth URL for example: http://127.0.0.1:8081/v1/auth
-DATA_API_AUTH_URL=http://127.0.0.1:8081/v1/auth
 #Auth username and password
 DATA_API_AUTH_USERNAME=cassandra
 DATA_API_AUTH_PASSWORD=cassandra

--- a/netlify-functions-ecommerce/connect.js
+++ b/netlify-functions-ecommerce/connect.js
@@ -29,8 +29,7 @@ module.exports = async function connect() {
     uri = process.env.DATA_API_URI;
     jsonApiConnectOptions = {
       username: process.env.DATA_API_AUTH_USERNAME,
-      password: process.env.DATA_API_AUTH_PASSWORD,
-      authUrl: process.env.DATA_API_AUTH_URL
+      password: process.env.DATA_API_AUTH_PASSWORD
     };
   }
   await mongoose.connect(uri, jsonApiConnectOptions);

--- a/typescript-express-reviews/.env.example
+++ b/typescript-express-reviews/.env.example
@@ -6,8 +6,6 @@ IS_ASTRA=
 #Fill the JSON API related details only when IS_ASTRA is set to 'false'
 #Local JSON API URL for example: http://127.0.0.1:8181/v1/ecommerce_test where 'ecommerce_test' is the keyspace name
 DATA_API_URI=http://127.0.0.1:8181/v1/ecommerce_test
-#Auth URL for example: http://127.0.0.1:8081/v1/auth
-DATA_API_AUTH_URL=http://127.0.0.1:8081/v1/auth
 #Auth username and password
 DATA_API_AUTH_USERNAME=cassandra
 DATA_API_AUTH_PASSWORD=cassandra

--- a/typescript-express-reviews/.env.test
+++ b/typescript-express-reviews/.env.test
@@ -1,4 +1,3 @@
 DATA_API_URI=http://127.0.0.1:8181/v1/reviews_test
 DATA_API_AUTH_USERNAME=cassandra
 DATA_API_AUTH_PASSWORD=cassandra
-DATA_API_AUTH_URL=http://localhost:8081/v1/auth

--- a/typescript-express-reviews/src/models/connect.ts
+++ b/typescript-express-reviews/src/models/connect.ts
@@ -6,7 +6,6 @@ const isAstra = process.env.IS_ASTRA ?? '';
 const dataAPIURI = process.env.DATA_API_URI ?? '';
 const username = process.env.DATA_API_AUTH_USERNAME ?? '';
 const password = process.env.DATA_API_AUTH_PASSWORD ?? '';
-const authUrl = process.env.DATA_API_AUTH_URL ?? '';
 
 const astraAPIEndpoint = process.env.ASTRA_API_ENDPOINT ?? '';
 const astraNamespace = process.env.ASTRA_NAMESPACE ?? '';
@@ -28,7 +27,7 @@ export default async function connect() {
     console.log('Connecting to', dataAPIURI);
     await mongoose.connect(
       dataAPIURI,
-      { username, password, authUrl } as mongoose.ConnectOptions
+      { username, password } as mongoose.ConnectOptions
     );
   }
 }


### PR DESCRIPTION
We no longer need DATA_API_AUTH_URL environment variable and `authUrl` param to `connect()`, so I've removed that from the sample apps