### PR TITLE
remove dotenv from discord-bot and typescript-express-reviews sample app

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     name: Discord Bot Sample App
     steps:
       ## Set up Stargate
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # v3.1.1
         with:
           node-version: ${{ matrix.node }}
-      
+
       - run: npm install
         working-directory: discord-bot
       - run: npm run lint
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     name: Ecommerce Sample App
     steps:
       ## Set up Stargate
@@ -84,7 +84,7 @@ jobs:
         uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # v3.1.1
         with:
           node-version: ${{ matrix.node }}
-      
+
       - run: npm install
         working-directory: netlify-functions-ecommerce
       - run: npm run lint
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     name: Reviews Sample App
     steps:
       ## Set up Stargate
@@ -127,7 +127,7 @@ jobs:
         uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # v3.1.1
         with:
           node-version: ${{ matrix.node }}
-      
+
       - run: npm install
         working-directory: typescript-express-reviews
       - run: npm run build
@@ -143,7 +143,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     name: Photography Sample App
     steps:
       ## Set up Stargate

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('dotenv').config();
-
 const { Routes } = require('discord.js');
 const { REST } = require('@discordjs/rest');
 const assert = require('assert');

--- a/discord-bot/dropCollections.js
+++ b/discord-bot/dropCollections.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('dotenv').config();
-
 const connect = require('./connect');
 const mongoose = require('./mongoose');
 

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('dotenv').config();
-
 // Require the necessary discord.js classes
 const { Client, Collection, GatewayIntentBits } = require('discord.js');
 const assert = require('assert');

--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -4,22 +4,22 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "clean-db": "node ./dropCollections",
+    "clean-db": "node --env-file=.env ./dropCollections",
     "lint": "eslint .",
-    "test": "mocha test/*.js",
-    "seed": "node ./seed",
-    "start": "node ./index.js"
+    "postinstall": "touch .env",
+    "test": "node --env-file=.env.test ./node_modules/mocha/bin/mocha test/*.js",
+    "seed": "node --env-file=.env ./seed",
+    "start": "node --env-file=.env ./index.js"
   },
   "author": "",
   "license": "ISC",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.6.0"
   },
   "dependencies": {
     "@discordjs/rest": "2.4.3",
     "@masteringjs/eslint-config": "0.1.1",
     "discord.js": "14.18.0",
-    "dotenv": "16.4.7",
     "mongoose": "^8.1",
     "stargate-mongoose": "0.6.10"
   },

--- a/discord-bot/seed.js
+++ b/discord-bot/seed.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('dotenv').config();
-
 const Bot = require('./models/bot');
 const connect = require('./connect');
 const mongoose = require('./mongoose');

--- a/discord-bot/test/setup.js
+++ b/discord-bot/test/setup.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('dotenv').config({ path: `${__dirname}/../.env.test` });
-
 const Bot = require('../models/bot');
 const { after, before } = require('mocha');
 const mongoose = require('../mongoose');

--- a/typescript-express-reviews/package.json
+++ b/typescript-express-reviews/package.json
@@ -6,18 +6,17 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "clean-db": "ts-node src/seed/dropCollections",
-    "seed": "ts-node src/seed/seed",
-    "start": "ts-node src/api",
-    "test": "ts-mocha tests/*.test.ts"
+    "clean-db": "node --env-file=.env ./node_modules/.bin/ts-node src/seed/dropCollections",
+    "seed": "node --env-file=.env ./node_modules/.bin/ts-node src/seed/seed",
+    "start": "node --env-file=.env ./node_modules/.bin/ts-node src/api",
+    "test": "node --env-file=.env.test ./node_modules/.bin/ts-mocha tests/*.test.ts"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=20.6.0"
   },
   "dependencies": {
     "@awaitjs/express": "0.9.0",
     "bcryptjs": "^3.0.0",
-    "dotenv": "16.4.7",
     "express": "4.x",
     "mongoose": "^8.1",
     "stargate-mongoose": "0.6.10"

--- a/typescript-express-reviews/src/api/index.ts
+++ b/typescript-express-reviews/src/api/index.ts
@@ -1,6 +1,3 @@
-import dotenv from 'dotenv';
-dotenv.config();
-
 import { addAsync } from '@awaitjs/express';
 import express from 'express';
 import register from './User/register';

--- a/typescript-express-reviews/src/seed/dropCollections.ts
+++ b/typescript-express-reviews/src/seed/dropCollections.ts
@@ -1,6 +1,3 @@
-import dotenv from 'dotenv';
-dotenv.config();
-
 import connect from '../models/connect';
 import mongoose from '../models/mongoose';
 

--- a/typescript-express-reviews/src/seed/seed.ts
+++ b/typescript-express-reviews/src/seed/seed.ts
@@ -1,6 +1,3 @@
-import dotenv from 'dotenv';
-dotenv.config();
-
 import connect from '../models/connect';
 import mongoose from '../models/mongoose';
 

--- a/typescript-express-reviews/tests/index.test.ts
+++ b/typescript-express-reviews/tests/index.test.ts
@@ -1,8 +1,3 @@
-import dotenv from 'dotenv';
-dotenv.config({
-  path: '.env.test'
-});
-
 import { after, before } from 'mocha';
 import connect from '../src/models/connect';
 import mongoose from 'mongoose';


### PR DESCRIPTION
Getting rid of dotenv dependency by using Node 20.6's `--env-file` flag. discord-bot and reviews are the only sample apps I've been able to remove it for so far, there's issues using `--env-file` with `netlify dev` that I still need to work around.